### PR TITLE
node 0.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: node_js
 node_js:
+  - "0.10"
   - "0.12"
   - "iojs"
+before_install:
+  - npm install -g npm@latest

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "through": "^2.3.7"
   },
   "dependencies": {
+    "babel-runtime": "^5.3.1",
     "chokidar": "^1.0.1",
     "duplexer": "^0.1.1",
     "glob": "^5.0.6",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf lib",
     "lint": "eslint src",
     "build": "npm-run-all clean lint build:lib",
-    "build:lib": "babel src --out-dir lib",
+    "build:lib": "babel --optional runtime src --out-dir lib",
     "test": "npm-run-all build test:mocha",
     "test:mocha": "mocha test/*.js --compilers js:babel/register --timeout 5000 --colors",
     "testing": "npm-run-all clean --parallel testing:*",
@@ -64,6 +64,7 @@
     "mkdirp": "^0.5.1",
     "resolve": "^1.1.6",
     "shell-quote": "^1.4.3",
+    "shelljs": "^0.4.0",
     "subarg": "^1.0.0"
   }
 }

--- a/test/copy.js
+++ b/test/copy.js
@@ -1,10 +1,13 @@
-import {execSync} from "child_process";
+import * as child_process from "child_process";
+import {exec} from "shelljs";
 import {expect} from "chai";
 import * as cpx from "../lib/index";
 import {setupTestDir,
         teardownTestDir,
         content} from "./util/util";
 import upperify from "./util/upperify";
+
+const execSync = child_process.execSync || exec;
 
 describe("The copy method", () => {
 


### PR DESCRIPTION
I had to do a couple of things to get this to work on node 0.10:

* include `babel-runtime` to support `Symbol`s
* polyfill execSync

Let me know what you think.