### PR TITLE
Add "text-summary" nyc reporter

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,10 @@
+{
+    "reporter": [
+        "html",
+        "text",
+        "text-summary"
+    ],
+    "require": [
+        "babel-register"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prebuild": "npm run clean",
     "build": "cross-env NODE_ENV=production babel src --out-dir .",
     "pretest": "run-s clean lint",
-    "test": "cross-env NODE_ENV=development nyc --require babel-register mocha test/*.js --timeout 60000",
+    "test": "cross-env NODE_ENV=development nyc mocha test/*.js --timeout 60000",
     "prewatch": "run-s clean lint",
     "watch": "cross-env NODE_ENV=development mocha test/*.js --compilers js:babel-register --timeout 60000 --watch --growl",
     "open-coverage": "nyc report -r lcov && opener coverage/lcov-report/index.html",


### PR DESCRIPTION
Also moved `nyc` configuration to `.nycrc` file.

Benefits _(to me)_ are:

  1. Test script got shorter 
  2. `nyc` configuration got centralized, becoming a default place for possible future additions/changes
  3. Test output gets amended by a handy summary, e.g.

```
  78 passing (4m)

---------------|----------|----------|----------|----------|----------------|
File           |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
---------------|----------|----------|----------|----------|----------------|
All files      |    90.09 |    75.93 |    95.83 |    89.84 |                |
 bin           |    88.04 |    81.08 |    94.44 |    87.91 |                |
  help.js      |      100 |      100 |      100 |      100 |                |
  index.js     |      100 |      100 |      100 |      100 |                |
  main.js      |    84.93 |    76.67 |    92.86 |    84.72 |... 139,155,156 |
  version.js   |      100 |      100 |      100 |      100 |                |
 lib           |    90.63 |       75 |    96.15 |    90.35 |                |
  copy-sync.js |      100 |      100 |      100 |      100 |                |
  copy.js      |    87.32 |    69.23 |      100 |    86.36 |... 144,154,162 |
  cpx.js       |    89.66 |    71.09 |    93.62 |    89.45 |... 455,478,541 |
  index.js     |    89.66 |    86.11 |      100 |    89.66 |       42,43,95 |
  queue.js     |      100 |    83.33 |      100 |      100 |                |
---------------|----------|----------|----------|----------|----------------|

=============================== Coverage summary ===============================
Statements   : 90.09% ( 400/444 )
Branches     : 75.93% ( 183/241 )
Functions    : 95.83% ( 92/96 )
Lines        : 89.84% ( 389/433 )
================================================================================
```
