### PR TITLE
New: pass outfile to transforms via _flags

### DIFF
--- a/bin/main.js
+++ b/bin/main.js
@@ -84,7 +84,7 @@ module.exports = function main(source, outDir, args) {
                 require(resolvePath(item.name)) :
                 require(resolveModule(item.name, {basedir: process.cwd()}))
             )
-            return (file) => createStream(file, item.argv)
+            return (file, opts) => createStream(file, Object.assign({_flags: opts}, item.argv))
         })
 
     // Merge commands and transforms as same as order of process.argv.

--- a/lib/utils/copy-file.js
+++ b/lib/utils/copy-file.js
@@ -55,7 +55,7 @@ function copyFileContent(source, output, transforms) {
         try {
             transforms
                 .reduce((input, factory) => {
-                    const t = factory(source)
+                    const t = factory(source, {outfile: output})
                     t.on("error", cleanup)
                     streams.push(t)
 


### PR DESCRIPTION
Adds _flags to the options, which is browserify compatible

Like browserify, you could expose other options passed to cpx to the transforms.