### PR TITLE
New: Added support for copying directories

### DIFF
--- a/bin/help.js
+++ b/bin/help.js
@@ -36,6 +36,7 @@ Options:
                               Use together '--watch' option.
     -p, --preserve            The flag to copy attributes of files.
                               This attributes are uid, gid, atime, and mtime.
+    -r --directory            The Flag to copy directory
     -t, --transform <name>    A module name to transform each file. cpx lookups
                                 the specified name via "require()".
     -u, --update              The flag to not overwrite files on destination if

--- a/bin/index.js
+++ b/bin/index.js
@@ -26,6 +26,7 @@ const args = subarg(process.argv.slice(2), {
         includeEmptyDirs: "include-empty-dirs",
         L: "dereference",
         p: "preserve",
+        r: "directory",
         t: "transform",
         u: "update",
         v: "verbose",

--- a/bin/main.js
+++ b/bin/main.js
@@ -114,6 +114,7 @@ module.exports = function main(source, outDir, args) {
         transform: mergedTransformFactories,
         dereference: args.dereference,
         includeEmptyDirs: args.includeEmptyDirs,
+        directory: args.directory,
         initialCopy: args.initial,
         preserve: args.preserve,
         update: args.update,

--- a/lib/utils/apply-action.js
+++ b/lib/utils/apply-action.js
@@ -47,7 +47,7 @@ module.exports = function applyAction(pattern, options, action) {
         }
 
         const globOptions = {
-            nodir: !options.includeEmptyDirs,
+            nodir: !(options.includeEmptyDirs || options.directory),
             silent: true,
             follow: Boolean(options.dereference),
             nosort: true,

--- a/lib/utils/copy-file-sync.js
+++ b/lib/utils/copy-file-sync.js
@@ -45,6 +45,7 @@ module.exports = function copyFileSync(source, output, options) {
 
     if (stat.isDirectory()) {
         fs.ensureDirSync(output)
+        fs.copySync(source, output)
     } else {
         fs.ensureDirSync(path.dirname(output))
         fs.copySync(source, output)

--- a/lib/utils/copy-file.js
+++ b/lib/utils/copy-file.js
@@ -100,6 +100,7 @@ module.exports = co.wrap(function* copyFile(source, output, options) {
 
     if (stat.isDirectory()) {
         yield fs.ensureDir(output)
+        yield fs.copy(source, output)
     } else {
         yield fs.ensureDir(path.dirname(output))
         yield copyFileContent(source, output, options.transform)

--- a/lib/utils/normalize-options.js
+++ b/lib/utils/normalize-options.js
@@ -62,6 +62,7 @@ module.exports = function normalizeOptions(source, outputDir, options) {
         clean: Boolean(options && options.clean),
         dereference: Boolean(options && options.dereference),
         includeEmptyDirs: Boolean(options && options.includeEmptyDirs),
+        directory: Boolean(options && options.directory),
         initialCopy: (options && options.initialCopy) !== false,
         outputDir,
         preserve: Boolean(options && options.preserve),


### PR DESCRIPTION
1. fs-extra's copy is used for copying directories
2. -r or --directory are the command line options
   for copying directories

Signed-off-by: pa1tirumani <btiruman@visteon.com>