### PR TITLE
Fix ENOENT when dest in tmpdir (#60)

### DIFF
--- a/lib/utils/normalize-path.js
+++ b/lib/utils/normalize-path.js
@@ -28,9 +28,8 @@ module.exports = function normalizePath(originalPath) {
         return null
     }
 
-    const cwd = process.cwd()
     const relativePath = path.resolve(originalPath)
-    const normalizedPath = path.relative(cwd, relativePath).replace(/\\/g, "/")
+    const normalizedPath = relativePath.replace(/\\/g, "/")
 
     if (/\/$/.test(normalizedPath)) {
         return normalizedPath.slice(0, -1)

--- a/test/copy.js
+++ b/test/copy.js
@@ -35,7 +35,8 @@ describe("The copy method", () => {
                 "test-ws/a/b/this-is.txt": "A pen",
                 "test-ws/a/b/that-is.txt": "A note",
                 "test-ws/a/b/no-copy.dat": "no-copy",
-            }))
+            })
+        )
         afterEach(() => teardownTestDir("test-ws"))
 
         /**
@@ -87,7 +88,8 @@ describe("The copy method", () => {
                 "test-ws/a/b/no-copy.dat": "no-copy",
                 "test-ws/b/b/remove.txt": "remove",
                 "test-ws/b/b/no-remove.dat": "no-remove",
-            }))
+            })
+        )
         afterEach(() => teardownTestDir("test-ws"))
 
         /**
@@ -231,7 +233,8 @@ describe("The copy method", () => {
                 "test-ws/a/hello.txt": "Hello",
                 "test-ws/a/b/pen.txt": "A pen",
                 "test-ws/a/c": null,
-            }))
+            })
+        )
         afterEach(() => teardownTestDir("test-ws"))
 
         /**
@@ -279,7 +282,8 @@ describe("The copy method", () => {
                 "test-ws/a/hello.txt": "Hello",
                 "test-ws/a/b/pen.txt": "A pen",
                 "test-ws/a/c": null,
-            }))
+            })
+        )
         afterEach(() => teardownTestDir("test-ws"))
 
         /**
@@ -324,7 +328,8 @@ describe("The copy method", () => {
                 "test-ws/a/b/this-is.txt": "A pen",
                 "test-ws/a/b/that-is.txt": "A note",
                 "test-ws/a/b/no-copy.dat": "no-copy",
-            }))
+            })
+        )
         afterEach(() => teardownTestDir("test-ws"))
 
         /**
@@ -673,7 +678,8 @@ describe("The copy method", () => {
 
     describe("should copy specified files with globs even if there are parentheses:", () => {
         beforeEach(() =>
-            setupTestDir({ "test-ws/a(paren)/hello.txt": "Hello" }))
+            setupTestDir({ "test-ws/a(paren)/hello.txt": "Hello" })
+        )
         afterEach(() => teardownTestDir("test-ws"))
 
         /**

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -73,11 +73,10 @@ const readFile = (module.exports.content = function content(path) {
  */
 module.exports.setupTestDir = function setupTestDir(dataset) {
     return Promise.all(
-        Object.keys(dataset).map(
-            path =>
-                dataset[path] == null
-                    ? fs.ensureDir(path)
-                    : writeFile(path, dataset[path])
+        Object.keys(dataset).map(path =>
+            dataset[path] == null
+                ? fs.ensureDir(path)
+                : writeFile(path, dataset[path])
         )
     ).then(() => delay(250))
 }

--- a/test/watch.js
+++ b/test/watch.js
@@ -115,7 +115,8 @@ describe("The watch method", () => {
                 "test-ws/a/b/this-is.txt": "A pen",
                 "test-ws/a/b/that-is.txt": "A note",
                 "test-ws/a/b/no-copy.dat": "no-copy",
-            }))
+            })
+        )
 
         /**
          * Verify.
@@ -267,7 +268,8 @@ describe("The watch method", () => {
                 "test-ws/a/b/this-is.txt": "A pen",
                 "test-ws/a/b/that-is.txt": "A note",
                 "test-ws/a/b/no-copy.dat": "no-copy",
-            }))
+            })
+        )
 
         /**
          * Verify.
@@ -319,7 +321,8 @@ describe("The watch method", () => {
                 "test-ws/a/b/no-copy.dat": "no-copy",
                 "test-ws/b/b/remove.txt": "remove",
                 "test-ws/b/b/no-remove.dat": "no-remove",
-            }))
+            })
+        )
 
         /**
          * Verify.
@@ -373,7 +376,8 @@ describe("The watch method", () => {
                 "test-ws/a/b/this-is.txt": "A pen",
                 "test-ws/a/b/that-is.txt": "A note",
                 "test-ws/a/b/no-copy.dat": "no-copy",
-            }))
+            })
+        )
 
         /**
          * Verify.
@@ -540,7 +544,8 @@ describe("The watch method", () => {
             setupTestDir({
                 "test-ws/a/hello.txt": "Hello",
                 "test-ws/a/hello.dat": "Hello",
-            }))
+            })
+        )
 
         /**
          * Verify.
@@ -591,7 +596,8 @@ describe("The watch method", () => {
             setupTestDir({
                 "test-ws/a/hello.txt": "Hello",
                 "test-ws/a/b/hello.txt": "Hello",
-            }))
+            })
+        )
 
         /**
          * Verify.
@@ -638,7 +644,8 @@ describe("The watch method", () => {
                 "test-ws/a/hello.txt": "Hello",
                 "test-ws/a/b/hello.txt": "Hello",
                 "test-ws/a/c": null,
-            }))
+            })
+        )
 
         /**
          * Verify.
@@ -684,7 +691,8 @@ describe("The watch method", () => {
             setupTestDir({
                 "test-ws/a/hello.txt": "Hello",
                 "test-ws/a/b/hello.txt": "Hello",
-            }))
+            })
+        )
 
         /**
          * Verify.
@@ -730,7 +738,8 @@ describe("The watch method", () => {
             setupTestDir({
                 //
                 "test-ws/a(paren)/hello.txt": "Hello",
-            }))
+            })
+        )
 
         /**
          * Verify.


### PR DESCRIPTION
Fixes https://github.com/mysticatea/cpx/issues/60 .

- Make `normalizePath()`returns absolute path
- Fix lint errors (to run tests)

I'm not sure how this change affects in other environment or cases. Let me know if anyone notice about this.