### PR TITLE
Bump patch Version for cpx from 1.5.0 to 1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cpx",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Copy file globs, watching for changes.",
   "engines": {
     "node": ">=6.5"


### PR DESCRIPTION
Here , chokidar has been removed , but the version was not bumped up. In our project, We are getting compliance issues for micromatch dependency which is getting pulled through cpx -> chokidar -> -> ...-> micromatch.Since the patch version was not upgraded we are still getting chokidar in our feed.